### PR TITLE
Fix bug where files have same name but differing paths

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -174,7 +174,7 @@ export default class FileDiffPlugin extends Plugin {
 					''
 				);
 				const originalFile = files.find(
-					(f) => f.name === originalFileName
+					(f) => f.name === originalFileName && (file.parent?.path ?? "") === (f.parent?.path ?? "")
 				);
 
 				if (originalFile) {


### PR DESCRIPTION
In my vault I might have two notes with the same name, but different paths. It will try to compare the wrong files in this case, I think this is because it doesn't consider the full path on this line:

https://github.com/friebetill/obsidian-file-diff/blob/ad651d827e68fde3f1e660c0c9d17ec0d95cfb41/src/main.ts#L176

A concrete example is I have the three files:

1. 01 Periodics/Daily/2024/02-Feb/2024-02-07.md
2. 01 Periodics/Daily/2024/02-Feb/2024-02-07.sync-conflict-20240208-011642-CB32Q7V.md

3. 04 Projects/03 Personal/Climbing/Sessions/2024-02-07.md


Obviously the tool should compare the first two, but it is comparing file 2 and 3, which have nothing in common.

I fixed this by adding a check when finding the corresponding file if the paths match. I didn't test it thoroughly, but it should handle the case where the conflicts are at the top level. 

PS: Thanks for the great plugin! I recently swapped to sync-thing but the conflicts drive me nuts and this makes it a little easier to deal with them.